### PR TITLE
Update youtube-dl to version 2013.11.15 to fix subtitle downloading.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4>=4.2.0
 mechanize>=0.2.5
-youtube-dl>=2013.05.14
+youtube-dl>=2013.11.15


### PR DESCRIPTION
This version contains a fix for an issue which prevents the old version from downloading subtitles:

https://github.com/rg3/youtube-dl/issues/1750

Previously, I would get 404's when attempting to download subtitles with edu_10gen_dl.

I can confirm that with this upstream fix in youtube-dl, subtitle downloading now works.
