### PR TITLE
Patch for MongoDB University support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EdX powered courses video downloader
 
-This script is intended to download course videos from http://education.10gen.com
+This script is intended to download course videos from https://university.mongodb.com
 or any other site 'Powered by EdX' (including, of course, http://edx.org itself).
 
 This script relies on [youtube-dl](https://github.com/rg3/youtube-dl/) project

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 EMAIL = 'your-email@he.re'
 PASSWORD='password'
-DOMAIN='courses.edx.org'
-#DOMAIN='education.10gen.com'
+#DOMAIN='courses.edx.org'
+DOMAIN='university.mongodb.com'
 
 
 YDL_PARAMS = \

--- a/edx_dl.py
+++ b/edx_dl.py
@@ -96,7 +96,7 @@ class EdXBrowser(object):
                         continue
 
                 i += 1
-                courseware_url = re.sub(r'\/info$','/courseware',course_url)
+                courseware_url = re.sub(r'\/(info|syllabus)$','/courseware',course_url)
                 self.courses.append({'name':course_name, 'url':courseware_url})
                 print '[%02i] %s' % (i, course_name)
 


### PR DESCRIPTION
MongoDB Education site is updated to MongoDB University. This patch add support of new url format.
