### PR TITLE
course landing page url has changed

### DIFF
--- a/edx_dl.py
+++ b/edx_dl.py
@@ -96,7 +96,7 @@ class EdXBrowser(object):
                         continue
 
                 i += 1
-                courseware_url = re.sub(r'\/info$','/courseware',course_url)
+                courseware_url = re.sub(r'\/syllabus$','/courseware',course_url)
                 self.courses.append({'name':course_name, 'url':courseware_url})
                 print '[%02i] %s' % (i, course_name)
 


### PR DESCRIPTION
the url has changed from /info to /syllabus
